### PR TITLE
Add note about 'ready'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,5 +77,5 @@ Ix.prototype.ready = function (fn) {
     self.once('_ready', function () { self.ready(fn) })
   } else if (self._latest !== self._change) {
     self.once('change', function () { self.ready(fn) })
-  } else fn()
+  } else process.nextTick(fn)
 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -148,8 +148,9 @@ finished.
 
 ## dex.ready(fn)
 
-`fn()` fires when the indexes have "caught up" to the latest known change in the
-hyperlog.
+Registers the callback `fn()` to fire when the indexes have "caught up" to the
+latest known change in the hyperlog. This gets fired once, and multiple ready
+functions can be set.
 
 ## dex.on('error', function (err) {})
 


### PR DESCRIPTION
Until I read the source, two things about `ready` weren't clear to me from the
current docs:

1. it only gets fired once
2. multiple ready functions can be specified